### PR TITLE
arm64: dts: qcom: sm6350-lena: Add qcom,rmtfs-mem node

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm6350-sony-xperia-lena-pdx213.dts
+++ b/arch/arm64/boot/dts/qcom/sm6350-sony-xperia-lena-pdx213.dts
@@ -11,6 +11,7 @@
 /* PMK8350 (in reality a PMK8003) is configured to use SID6 instead of 0 */
 #define PMK8350_SID 6
 
+#include <dt-bindings/firmware/qcom,scm.h>
 #include <dt-bindings/iio/qcom,spmi-adc7-pmk8350.h>
 #include <dt-bindings/leds/common.h>
 #include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
@@ -175,6 +176,22 @@
 		enable-active-high;
 
 		vin-supply = <&pm6350_l6>;
+	};
+
+	reserved-memory {
+		/*
+		 * The rmtfs memory region in downstream is 'dynamically allocated'
+		 * but given the same address every time. Hard code it as this address is
+		 * where the modem firmware expects it to be.
+		 */
+		rmtfs@fe901000 {
+			compatible = "qcom,rmtfs-mem";
+			reg = <0x0 0xfe901000 0x0 0x280000>;
+			no-map;
+
+			qcom,client-id = <1>;
+			qcom,vmid = <QCOM_SCM_VMID_MSS_MSA>;
+		};
 	};
 };
 


### PR DESCRIPTION
Adds the qcom,rmtfs-mem node required for the 


I forgot to add this to an earlier commit...

Should've added it to either 292aa982a4207b6efb267e7d911bfe16ace33434 or 3debe3ee57295f0310272bb077cac0daa6c8fd67, I guess.